### PR TITLE
refs #44 Reduce reconcile events for nodemanager and awsnodemanager

### DIFF
--- a/pkg/controllers/awsnoderefresher/complete.go
+++ b/pkg/controllers/awsnoderefresher/complete.go
@@ -16,6 +16,7 @@ func (r *AWSNodeRefresherReconciler) refreshComplete(ctx context.Context, refres
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherCompleted
 	refresher.Status.UpdateStartTime = nil
 	refresher.Status.ReplaceTargetNode = nil
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return err

--- a/pkg/controllers/awsnoderefresher/decrease.go
+++ b/pkg/controllers/awsnoderefresher/decrease.go
@@ -19,6 +19,7 @@ func (r *AWSNodeRefresherReconciler) refreshDecrease(ctx context.Context, refres
 
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateDecreasing
 	refresher.Status.LastASGModifiedTime = &now
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return err
@@ -47,6 +48,7 @@ func (r *AWSNodeRefresherReconciler) retryDecrease(ctx context.Context, refreshe
 
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateDecreasing
 	refresher.Status.LastASGModifiedTime = &now
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return false, err

--- a/pkg/controllers/awsnoderefresher/increase.go
+++ b/pkg/controllers/awsnoderefresher/increase.go
@@ -26,6 +26,7 @@ func (r *AWSNodeRefresherReconciler) refreshIncrease(ctx context.Context, refres
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateIncreasing
 	refresher.Status.UpdateStartTime = &now
 	refresher.Status.LastASGModifiedTime = &now
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return err
@@ -57,6 +58,7 @@ func (r *AWSNodeRefresherReconciler) retryIncrease(ctx context.Context, refreshe
 	}
 
 	refresher.Status.LastASGModifiedTime = &now
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return false, err

--- a/pkg/controllers/awsnoderefresher/replace.go
+++ b/pkg/controllers/awsnoderefresher/replace.go
@@ -27,6 +27,7 @@ func (r *AWSNodeRefresherReconciler) refreshReplace(ctx context.Context, refresh
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateReplacing
 	refresher.Status.LastASGModifiedTime = &now
 	refresher.Status.ReplaceTargetNode = target
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return err
@@ -68,6 +69,7 @@ func findDeleteTarget(nodes []operatorv1alpha1.AWSNode) (*operatorv1alpha1.AWSNo
 
 func (r *AWSNodeRefresherReconciler) refreshNextReplace(ctx context.Context, refresher *operatorv1alpha1.AWSNodeRefresher) error {
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateIncreasing
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return err
@@ -85,6 +87,7 @@ func (r *AWSNodeRefresherReconciler) retryReplace(ctx context.Context, refresher
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateReplacing
 	refresher.Status.LastASGModifiedTime = &now
 	refresher.Status.ReplaceTargetNode = target
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return false, err

--- a/pkg/controllers/awsnoderefresher/wait.go
+++ b/pkg/controllers/awsnoderefresher/wait.go
@@ -16,6 +16,7 @@ func (r *AWSNodeRefresherReconciler) refreshAWSWait(ctx context.Context, refresh
 		return nil
 	}
 	refresher.Status.Phase = operatorv1alpha1.AWSNodeRefresherUpdateAWSWaiting
+	refresher.Status.Revision += 1
 	if err := r.Client.Update(ctx, refresher); err != nil {
 		klog.Errorf(ctx, "failed to update refresher: %v", err)
 		return err


### PR DESCRIPTION
closes #44 

- [x] Stop update event when all nodes are synced
- [x] Add external event to watch resources in a certain time
