### PR TITLE
refs #119 Fix node-label of control-plane for k8s 1.24

### DIFF
--- a/pkg/controllers/nodemanager/controller.go
+++ b/pkg/controllers/nodemanager/controller.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	NodeMasterLabel = "node-role.kubernetes.io/master"
+	NodeMasterLabel = "node-role.kubernetes.io/control-plane"
 	NodeWorkerLabel = "node-role.kubernetes.io/node"
 )
 


### PR DESCRIPTION
fixes #119 