### PR TITLE
Inject client manually

### DIFF
--- a/pkg/controllers/awsnodemanager/controller.go
+++ b/pkg/controllers/awsnodemanager/controller.go
@@ -105,6 +105,10 @@ func (r *AWSNodeManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+	err = external.InjectClient(mgr.GetClient())
+	if err != nil {
+		return err
+	}
 	src := source.Channel(external.Channel, &handler.TypedEnqueueRequestForObject[*operatorv1alpha1.AWSNodeManager]{})
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/controllers/awsnoderefresher/controller.go
+++ b/pkg/controllers/awsnoderefresher/controller.go
@@ -102,6 +102,10 @@ func (r *AWSNodeRefresherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+	err = external.InjectClient(mgr.GetClient())
+	if err != nil {
+		return err
+	}
 	src := source.Channel(external.Channel, &handler.TypedEnqueueRequestForObject[*operatorv1alpha1.AWSNodeRefresher]{})
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/controllers/awsnodereplenisher/controller.go
+++ b/pkg/controllers/awsnodereplenisher/controller.go
@@ -104,6 +104,10 @@ func (r *AWSNodeReplenisherReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if err != nil {
 		return err
 	}
+	err = external.InjectClient(mgr.GetClient())
+	if err != nil {
+		return err
+	}
 	src := source.Channel(external.Channel, &handler.TypedEnqueueRequestForObject[*operatorv1alpha1.AWSNodeReplenisher]{})
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
because it was removed in controller-runtime v0.15.

We have an error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1b3d425]

goroutine 48 [running]:
github.com/h3poteto/node-manager/pkg/controllers/awsnodemanager.(*AWSNodeManagerReconciler).SetupWithManager.func1({0x288db88, 0xc00059c0f0}, {0x0, 0x0})
        /workspace/pkg/controllers/awsnodemanager/controller.go:93 +0x45
github.com/h3poteto/node-manager/pkg/util/externalevent.(*externalEventWatcher[...]).Start(0x288d900, {0x288db88, 0xc00059c0f0})
        /workspace/pkg/util/externalevent/watcher.go:45 +0x128
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc00003eee0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.6/pkg/manager/runnable_group.go:226 +0xc8
created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 14
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.6/pkg/manager/runnable_group.go:210 +0x19d
```